### PR TITLE
make_cia: Remove unused CERT_CONTEXT definition

### DIFF
--- a/make_cia/settings.h
+++ b/make_cia/settings.h
@@ -34,16 +34,6 @@ typedef struct
 } __attribute__((__packed__))
 CERT_BUFF;
 
-
-typedef struct
-{
-	CERT_BUFF ca;
-	CERT_BUFF ticket;
-	CERT_BUFF tmd;
-} __attribute__((__packed__))
-CERT_CONTEXT;
-
-
 typedef struct
 {
 	u8 modulus[0x100];


### PR DESCRIPTION
CERT_CONTEXT is also defined on Windows in wincrypt.h and this prevents make_cia to be compiled on Windows correctly
